### PR TITLE
Support bitrise CLI 1.43.0 with version 10 bitrise.yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 11
+format_version: 10
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:


### PR DESCRIPTION
### Checklist

- Requires no release

### Context

Support bitrise CLI 1.43.0 with version 10 bitrise.yml.
<!--- One sentence summary on why the change is needed. -->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
