### PR TITLE
Include visionOS as supported platform

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ type Config struct {
 
 	IpaPath           string `env:"ipa_path"`
 	PkgPath           string `env:"pkg_path"`
-	Platform          string `env:"platform,opt[auto,ios,macos,tvos]"`
+	Platform          string `env:"platform,opt[auto,ios,macos,tvos,visionos]"`
 	ItunesConnectUser string `env:"itunescon_user"`
 	AdditionalParams  string `env:"altool_options"`
 	RetryTimes        string `env:"retries"`

--- a/main.go
+++ b/main.go
@@ -51,9 +51,10 @@ type Config struct {
 type platformType string
 
 const (
-	iOS   platformType = "ios"
-	tvOS  platformType = "appletvos"
-	macOS platformType = "macos"
+	iOS      platformType = "ios"
+	tvOS     platformType = "appletvos"
+	macOS    platformType = "macos"
+	visionOS platformType = "visionos"
 )
 
 func (cfg Config) validateArtifact() error {
@@ -107,6 +108,8 @@ func getPlatformType(ipaPath, platform string) platformType {
 			return macOS
 		case "iphoneos", "iphonesimulator", "watchos", "watchsimulator":
 			return iOS
+		case "xros", "xrossimulator":
+			return visionOS
 		default:
 			return fallback()
 		}
@@ -116,6 +119,8 @@ func getPlatformType(ipaPath, platform string) platformType {
 		return macOS
 	case "tvos":
 		return tvOS
+	case "visionos":
+		return visionOS
 	default:
 		return fallback()
 	}

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func getPlatformType(ipaPath, platform string) platformType {
 			return macOS
 		case "iphoneos", "iphonesimulator", "watchos", "watchsimulator":
 			return iOS
-		case "xros", "xrossimulator":
+		case "xros", "xrsimulator":
 			return visionOS
 		default:
 			return fallback()

--- a/step.yml
+++ b/step.yml
@@ -139,6 +139,7 @@ inputs:
     - ios
     - macos
     - tvos
+    - visionos
 - retries: "10"
   opts:
     title: Retry times


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

When using this step to upload a visionOS build to App Store Connect, the `type` of the binary is recognised as `ios` and the upload fails with the error:
> Error: Asset validation failed Type Mismatch. The value for the Info.plist key CFBundleIcons.CFBundlePrimaryIcon is not of the required type for that key. See the Information Property List Key Reference at https://developer.apple.com/library/ios/documentation/general/Reference/InfoPlistKeyReference/Introduction/Introduction.html#//apple_ref/doc/uid/TP40009248-SW1 (ID: 0132c25e-0b12-427c-9706-965065a0445a) (90039)

This is because App Store Connect is trying to understand/parse the uploaded binary as an iOS binary and expecting an icon format that a build for visionOS does not provide. To fix it, the step needs to pass the correct property for the `--type` parameter on `altool`, outputting a command similar to:

```sh
$ xcrun "altool" "--upload-app" "-f" [BITRISE_IPA_PATH] "--type" "visionos" "--apiKey" [REDACTED] "--apiIssuer" [REDACTED]
```

### Changes

1. Include new `visionos` in the list of Platforms input
2. Include the new visionOS type in the platformType
3. Update the getPlatformType to recognise the new platform type

### Notes

This solution was tested on local builds and builds running on Bitrise platform (pointing to fork/branch)
